### PR TITLE
Return the correct downloadable url from dropbox

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@
 const url = require('url')
 const Dropbox = require('dropbox').Dropbox
 const fetch = require('isomorphic-fetch')
+const dropBoxResultUrlRegularExpression = /www.dropbox.com/;
+const dropBoxDownloadUrl = 'dl.dropboxusercontent.com'
 
 module.exports = {
   provider: 'dropbox',
@@ -20,17 +22,19 @@ module.exports = {
           dbx.filesUpload({ path: `/uploads/${file.hash}${file.ext}`, contents: Buffer.from(file.buffer, 'binary') })
             .then(uploadedFile => dbx.sharingCreateSharedLinkWithSettings({ path: uploadedFile.path_display }))
             .then(fileUrl => {
+              console.log(fileUrl);
               const { protocol, hostname, pathname } = url.parse(fileUrl.url)
               file.public_id = fileUrl.id
               file.url = url.format({
                 protocol,
-                hostname,
+                hostname: hostname.replace(dropBoxResultUrlRegularExpression,dropBoxDownloadUrl),
                 pathname,
                 query: {
                   raw: 1
                 }
               })
-              return resolve()
+             
+               return resolve()
             })
             .catch(function (err) {
               return reject(err)

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ module.exports = {
           dbx.filesUpload({ path: `/uploads/${file.hash}${file.ext}`, contents: Buffer.from(file.buffer, 'binary') })
             .then(uploadedFile => dbx.sharingCreateSharedLinkWithSettings({ path: uploadedFile.path_display }))
             .then(fileUrl => {
-              console.log(fileUrl);
+              
               const { protocol, hostname, pathname } = url.parse(fileUrl.url)
               file.public_id = fileUrl.id
               file.url = url.format({


### PR DESCRIPTION
**Issue:**
After upload completed, the resulted url is something like:
https://www.dropbox.com/s/XXXX/file.ext
This URL is not downloadable, so the file is successfully uploaded to dropbox, however, the image or file is saved with a broken link.

**Solution Provided:**
I changed the parsing of the url to mount this by replacing the term in hostname from "www.dropbox.com" to "dl.dropboxusercontent.com"

